### PR TITLE
Add '_Alignof' to Lexer.x (fixes #7)

### DIFF
--- a/src/Language/C/Parser/Lexer.x
+++ b/src/Language/C/Parser/Lexer.x
@@ -294,6 +294,7 @@ idkwtok ('_' : 'N' : 'o' : 'r' : 'e' : 't' : 'u' : 'r' : 'n' : []) = tok 9 CTokN
 idkwtok ('_' : '_' : 'a' : 'l' : 'i' : 'g' : 'n' : 'o' : 'f' : []) = tok 9 CTokAlignof
 idkwtok ('a' : 'l' : 'i' : 'g' : 'n' : 'o' : 'f' : []) = tok 7 CTokAlignof
 idkwtok ('_' : '_' : 'a' : 'l' : 'i' : 'g' : 'n' : 'o' : 'f' : '_' : '_' : []) = tok 11 CTokAlignof
+idkwtok ('_' : 'A' : 'l' : 'i' : 'g' : 'n' : 'o' : 'f' : []) = tok 8 CTokAlignof
 idkwtok ('_' : '_' : 'a' : 's' : 'm' : []) = tok 5 CTokAsm
 idkwtok ('a' : 's' : 'm' : []) = tok 3 CTokAsm
 idkwtok ('_' : '_' : 'a' : 's' : 'm' : '_' : '_' : []) = tok 7 CTokAsm


### PR DESCRIPTION
Tested by doing a `cabal build` with no issues.

I tried running the test harness but it looks like it's broken -- complains about "CTest: osx-1.c: copyFile: does not exist (No such file or directory)" -- is this a known issue?