### PR TITLE
Parse (and ignore) Clang __attribute__((availability(id=major.minor.rev)))

### DIFF
--- a/src/Language/C/Parser/Lexer.x
+++ b/src/Language/C/Parser/Lexer.x
@@ -122,7 +122,8 @@ $infname  = . # [ \\ \" ]             -- valid character in a filename
 @floatsuffix    = [fFlL]
 @floatgnusuffix = @floatsuffix@gnusuffix?|@gnusuffix@floatsuffix?
 
-
+-- clang version literals with a major.minor.rev
+@clangversion = @intpart\.@intpart\.@intpart
 
 tokens :-
 
@@ -182,6 +183,9 @@ $digitNZ$digit*@intgnusuffix?   { token_plus CTokILit (readCInteger DecRepr) }
 L\'($inchar|@charesc)\' { token CTokCLit (cChar_w . fst . unescapeChar . tail . tail) }
 \'($inchar|@charesc){2,}\' { token CTokCLit (flip cChars False . unescapeMultiChars .tail) }
 L\'($inchar|@charesc){2,}\' { token CTokCLit (flip cChars True . unescapeMultiChars . tail . tail) }
+
+-- Clang version literals
+@clangversion           { token (\pos -> CTokClangC pos . ClangCVersionTok) readClangCVersion }
 
 -- float constants (follows K&R A2.5.3. C99 6.4.4.2)
 --

--- a/src/Language/C/Parser/Parser.y
+++ b/src/Language/C/Parser/Parser.y
@@ -108,7 +108,7 @@ import qualified Data.List as List
 import Control.Monad (mplus)
 import Language.C.Parser.Builtin   (builtinTypeNames)
 import Language.C.Parser.Lexer     (lexC, parseError)
-import Language.C.Parser.Tokens    (CToken(..), GnuCTok(..), posLenOfTok)
+import Language.C.Parser.Tokens    (CToken(..), GnuCTok(..), ClangCTok (..), posLenOfTok)
 import Language.C.Parser.ParserMonad (P, failP, execParser, getNewName, addTypedef, shadowTypedef, getCurrentPosition,
                                       enterScope, leaveScope, getLastToken, getSavedToken, ParseError(..))
 
@@ -245,6 +245,7 @@ tyident		{ CTokTyIdent _ $$ }		-- `typedef-name' identifier
 "__builtin_va_arg"		{ CTokGnuC GnuCVaArg    _ }
 "__builtin_offsetof"		{ CTokGnuC GnuCOffsetof _ }
 "__builtin_types_compatible_p"	{ CTokGnuC GnuCTyCompat _ }
+clangcversion   { CTokClangC _ (ClangCVersionTok $$) } -- Clang version literal
 
 %%
 
@@ -2075,6 +2076,8 @@ string_literal_list
   : cstr			{ case $1 of CTokSLit _ s -> singleton s }
   | string_literal_list cstr	{ case $2 of CTokSLit _ s -> $1 `snoc` s }
 
+clang_version_literal :: { ClangCVersion }
+  : clangcversion       { $1 }
 
 identifier :: { Ident }
 identifier
@@ -2118,9 +2121,11 @@ attribute
 attribute_params :: { Reversed [CExpr] }
 attribute_params
   : constant_expression					              { singleton $1 }
+  | unary_expression assignment_operator clang_version_literal { Reversed [] }
   | unary_expression assignment_operator unary_expression { Reversed [] }
   | attribute_params ',' constant_expression	{ $1 `snoc` $3 }
   | attribute_params ',' unary_expression assignment_operator unary_expression { $1 }
+  | attribute_params ',' unary_expression assignment_operator clang_version_literal { $1 }
 
 {
 

--- a/src/Language/C/Parser/Tokens.hs
+++ b/src/Language/C/Parser/Tokens.hs
@@ -11,11 +11,11 @@
 --  C Tokens for the C lexer.
 --
 -----------------------------------------------------------------------------
-module Language.C.Parser.Tokens (CToken(..), posLenOfTok, GnuCTok(..)) where
+module Language.C.Parser.Tokens (CToken(..), posLenOfTok, GnuCTok(..), ClangCTok(..)) where
 
 import Language.C.Data.Position    (Position, Pos(..), PosLength)
 import Language.C.Data.Ident       (Ident, identToString)
-import Language.C.Syntax.Constants (CChar, CInteger, CFloat, CString)
+import Language.C.Syntax.Constants (CChar, CInteger, CFloat, CString, ClangCVersion)
 
 -- token definition
 -- ----------------
@@ -139,6 +139,7 @@ data CToken = CTokLParen   !PosLength            -- `('
               -- not generated here, but in `CParser.parseCHeader'
             | CTokTyIdent  !PosLength !Ident     -- `typedef-name' identifier
             | CTokGnuC !GnuCTok !PosLength       -- special GNU C tokens
+            | CTokClangC !PosLength !ClangCTok   -- special Clang C tokens
             | CTokEof                           -- end of file
 
 -- special tokens used in GNU C extensions to ANSI C
@@ -150,6 +151,8 @@ data GnuCTok = GnuCAttrTok              -- `__attribute__'
              | GnuCTyCompat             -- `__builtin_types_compatible_p'
              | GnuCComplexReal          -- `__real__'
              | GnuCComplexImag          -- `__imag__'
+
+data ClangCTok = ClangCVersionTok !ClangCVersion -- version constant from 'availability' attribute
 
 instance Pos CToken where
   posOf = fst . posLenOfTok
@@ -258,6 +261,7 @@ posLenOfTok (CTokSLit     pos _) = pos
 posLenOfTok (CTokIdent    pos _) = pos
 posLenOfTok (CTokTyIdent  pos _) = pos
 posLenOfTok (CTokGnuC   _ pos  ) = pos
+posLenOfTok (CTokClangC   pos _) = pos
 posLenOfTok CTokEof = error "tokenPos: Eof"
 
 instance Show CToken where
@@ -369,4 +373,5 @@ instance Show CToken where
   showsPrec _ (CTokGnuC GnuCVaArg    _) = showString "__builtin_va_arg"
   showsPrec _ (CTokGnuC GnuCOffsetof _) = showString "__builtin_offsetof"
   showsPrec _ (CTokGnuC GnuCTyCompat _) = showString "__builtin_types_compatible_p"
+  showsPrec _ (CTokClangC _ (ClangCVersionTok v)) = shows v
   showsPrec _ CTokEof = error "show CToken : CTokEof"

--- a/src/Language/C/Syntax/Constants.hs
+++ b/src/Language/C/Syntax/Constants.hs
@@ -23,6 +23,8 @@ module Language.C.Syntax.Constants (
   cFloat,  CFloat(..), readCFloat,
   -- * C string literals
   cString, cString_w, CString(..), getCString, showStringLit, concatCStrings,
+  -- * Clang C version literals
+  ClangCVersion(..), readClangCVersion,
 )
 where
 import Data.Bits
@@ -150,6 +152,17 @@ cFloat = CFloat . show
 -- dummy implementation
 readCFloat :: String -> CFloat
 readCFloat = CFloat
+
+-- | Clang dotted version literal
+-- <https://clang.llvm.org/docs/AttributeReference.html#availability>
+data ClangCVersion = ClangCVersion
+                     !String
+                     deriving (Eq,Ord,Data,Typeable)
+instance Show ClangCVersion where
+  showsPrec _ (ClangCVersion internal) = showString internal
+
+readClangCVersion :: String -> ClangCVersion
+readClangCVersion = ClangCVersion
 
 -- | C String literals
 data CString = CString


### PR DESCRIPTION
If the version is just major.minor, it will lex as a float literal.
If it's major.minor.rev it will lex as a new clang version token.

In either case the parser will throw those attribute parameters out. (As it
currently does with other 'unary_expr = unaray_expr' attribute parameters).

Fixes #19 