### PR TITLE
Allow typedef redefiniton if it denotes the same type

### DIFF
--- a/examples/ComputeSize.hs
+++ b/examples/ComputeSize.hs
@@ -87,7 +87,7 @@ computeRefClosure all_comps initial_comps =
         | otherwise = error $ "Internal Error: Could not find definition for "++show ref
     fromCompTy _ = Nothing
     fromDirectRefdType (DirectType tyname _ _) = Just tyname
-    fromDirectRefdType (TypeDefType (TypeDefRef _ ref _) _ _) = (fromDirectRefdType.fromJust) ref
+    fromDirectRefdType (TypeDefType (TypeDefRef _ ty _) _ _) = fromDirectRefdType ty
     fromDirectRefdType (ArrayType ty _ _ _) = fromDirectRefdType ty
     fromDirectRefdType _ = Nothing
 

--- a/language-c.cabal
+++ b/language-c.cabal
@@ -1,5 +1,5 @@
 Name:           language-c
-Version:        0.5.1
+Version:        0.6
 Cabal-Version:  >= 1.8
 Build-Type:     Simple
 License:        BSD3

--- a/src/Language/C/Analysis/ConstEval.hs
+++ b/src/Language/C/Analysis/ConstEval.hs
@@ -58,7 +58,7 @@ sizeofType md n (ArrayType bt (ArraySize _ sz) _ _) =
             astError (nodeInfo sz) $
             "array size is not a constant: " ++ (render . pretty) sz
             -}
-sizeofType md n (TypeDefType (TypeDefRef _ (Just t) _) _ _) = sizeofType md n t
+sizeofType md n (TypeDefType (TypeDefRef _ t _) _ _) = sizeofType md n t
 sizeofType md _ (FunctionType _ _) = return $ ptrSize md
 sizeofType _ n t = astError (nodeInfo n) $
                  "can't find size of type: " ++ (render . pretty) t
@@ -73,7 +73,7 @@ alignofType md _ (DirectType (TyBuiltin b) _ _) = return $ builtinAlign md b
 alignofType md _ (PtrType _ _ _)  = return $ ptrAlign md
 alignofType md _ (ArrayType _ (UnknownArraySize _) _ _) = return $ ptrAlign md
 alignofType md n (ArrayType bt (ArraySize _ _) _ _) = alignofType md n bt
-alignofType md n (TypeDefType (TypeDefRef _ (Just t) _) _ _) = alignofType md n t
+alignofType md n (TypeDefType (TypeDefRef _ t _) _ _) = alignofType md n t
 alignofType _ n t = astError (nodeInfo n) $
                  "can't find alignment of type: " ++ (render . pretty) t
 

--- a/src/Language/C/Analysis/DeclAnalysis.hs
+++ b/src/Language/C/Analysis/DeclAnalysis.hs
@@ -289,7 +289,7 @@ mergeTypeAttributes node_info quals attrs typ =
     merge quals' attrs' tyf = return $ tyf (mergeTypeQuals quals quals') (attrs' ++ attrs)
 
 typeDefRef :: (MonadCError m, MonadSymtab m) => NodeInfo -> Ident -> m TypeDefRef
-typeDefRef t_node name = lookupTypeDef name >>= \ty -> return (TypeDefRef name (Just ty) t_node)
+typeDefRef t_node name = lookupTypeDef name >>= \ty -> return (TypeDefRef name ty t_node)
 
 -- extract a struct\/union
 -- we emit @declStructUnion@ and @defStructUnion@ actions

--- a/src/Language/C/Analysis/Export.hs
+++ b/src/Language/C/Analysis/Export.hs
@@ -225,7 +225,7 @@ exportAttrs = map exportAttr where
 
 fromDirectType :: Type -> TypeName
 fromDirectType (DirectType ty _ _) = ty
-fromDirectType (TypeDefType (TypeDefRef _ ref _) _ _) = maybe (error "undefined typeDef") fromDirectType ref
+fromDirectType (TypeDefType (TypeDefRef _ ty _) _ _) = fromDirectType ty
 fromDirectType _ = error "fromDirectType"
 
 ni :: NodeInfo

--- a/src/Language/C/Analysis/SemRep.hs
+++ b/src/Language/C/Analysis/SemRep.hs
@@ -388,7 +388,7 @@ data BuiltinType = TyVaList
 
 -- | typdef references
 -- If the actual type is known, it is attached for convenience
-data TypeDefRef = TypeDefRef Ident (Maybe Type) NodeInfo
+data TypeDefRef = TypeDefRef Ident Type NodeInfo
                deriving (Typeable, Data {-! ,CNode !-})
 
 -- | integral types (C99 6.7.2.2)

--- a/src/Language/C/Analysis/TravMonad.hs
+++ b/src/Language/C/Analysis/TravMonad.hs
@@ -58,6 +58,7 @@ import Language.C.Data.RList as RList
 import Language.C.Analysis.Builtins
 import Language.C.Analysis.SemError
 import Language.C.Analysis.SemRep
+import Language.C.Analysis.TypeUtils (sameType)
 import Language.C.Analysis.DefTable hiding (enterBlockScope,leaveBlockScope,
                                             enterFunctionScope,leaveFunctionScope)
 import qualified Language.C.Analysis.DefTable as ST
@@ -137,9 +138,16 @@ handleEnumeratorDef enumerator = do
     return ()
 
 handleTypeDef :: (MonadTrav m) => TypeDef -> m ()
-handleTypeDef typeDef@(TypeDef ident _ _ _) = do
+handleTypeDef typeDef@(TypeDef ident t1 _ _) = do
     redecl <- withDefTable $ defineTypeDef ident typeDef
-    checkRedef (show ident) typeDef redecl
+    -- C11 6.7/3 If an identifier has no linkage, there shall be no more than
+    -- one declaration of the identifier (in a declarator or type specifier)
+    -- with the same scope and in the same name space, except that: a typedef
+    -- name may be redefined to denote the same type as it currently does,
+    -- provided that type is not a variably modified type;
+    case redecl of
+      Redeclared (Left (TypeDef _ t2 _ _)) | sameType t1 t2 -> return ()
+      _ -> checkRedef (show ident) typeDef redecl
     handleDecl (TypeDefEvent typeDef)
     return ()
 

--- a/src/Language/C/Analysis/TypeCheck.hs
+++ b/src/Language/C/Analysis/TypeCheck.hs
@@ -296,8 +296,9 @@ binopType op t1 t2 =
           (DirectType tn1 _ _, DirectType tn2 _ _) ->
                 case arithmeticConversion tn1 tn2 of
                   Just _ -> return boolType
-                  Nothing -> fail
-                             "incompatible arithmetic types in comparison"
+                  Nothing -> fail $ render $
+                             text "incompatible arithmetic types in comparison: "
+                             <+> pretty t1 <+> text "and" <+> pretty t2
           (PtrType (DirectType TyVoid _ _) _ _, _)
             | isPointerType t2' -> return boolType
           (_, PtrType (DirectType TyVoid _ _) _ _)

--- a/src/Language/C/Analysis/TypeCheck.hs
+++ b/src/Language/C/Analysis/TypeCheck.hs
@@ -165,14 +165,8 @@ compositeType t1 t2 | isPointerType t1 && isPointerType t2 =
      return (PtrType t quals attrs)
 compositeType (TypeDefType tdr1 q1 a1) (TypeDefType tdr2 q2 a2) =
   case (tdr1, tdr2) of
-    (TypeDefRef i1 Nothing _, TypeDefRef i2 _ _) -> doTypeDef i1 i2 tdr1
-    (TypeDefRef i1 _ _, TypeDefRef i2 Nothing _) -> doTypeDef i1 i2 tdr2
-    (TypeDefRef _ (Just t1) _, TypeDefRef _ (Just t2) _) ->
+    (TypeDefRef _ t1 _, TypeDefRef _ t2 _) ->
       compositeType t1 t2
-  where doTypeDef i1 i2 tdr =
-          do when (i1 /= i2) $ fail $ "incompatible typedef types: "
-                               ++ identToString i1 ++ ", " ++ identToString i2
-             return (TypeDefType tdr (mergeTypeQuals q1 q2) (mergeAttributes a1 a2))
 compositeType (FunctionType ft1 attrs1) (FunctionType ft2 attrs2) =
   case (ft1, ft2) of
     (FunType rt1 args1 varargs1, FunType rt2 args2 varargs2) ->

--- a/src/Language/C/Analysis/TypeUtils.hs
+++ b/src/Language/C/Analysis/TypeUtils.hs
@@ -28,12 +28,16 @@ module Language.C.Analysis.TypeUtils (
     derefTypeDef,
     deepDerefTypeDef,
     canonicalType,
+    -- * Type comparisons
+    sameType,
     -- * Other utilities
     getIntType,
     getFloatType
 ) where
 
 import Language.C.Analysis.SemRep
+import Language.C.Data.Node (CNode(..))
+import Language.C.Syntax.AST (CExpression (..), CConstant (..))
 import Language.C.Syntax.Constants
 
 -- | Constructor for a simple integral type.
@@ -200,6 +204,100 @@ deepDerefTypeDef (TypeDefType (TypeDefRef _ t _) q a) =
   (typeAttrsUpd (mergeAttributes a) . typeQualsUpd (mergeTypeQuals q))
   (deepDerefTypeDef t)
 deepDerefTypeDef t = t
+
+-- | True iff Type is a variable length array or a derived type thereof.
+-- Variably modified types have function or block scope, so only some
+-- constructions are possible.
+isVariablyModifiedType :: Type -> Bool
+isVariablyModifiedType t =
+  case derefTypeDef t of
+    TypeDefType {} -> error "impossible: derefTypeDef t returned a TypeDefType"
+    DirectType {} -> False
+    PtrType t _ _ -> isVariablyModifiedType t
+    ArrayType _ sz _ _ -> isVariableArraySize sz
+    FunctionType {} -> False
+  where
+    isVariableArraySize :: ArraySize -> Bool
+    isVariableArraySize (UnknownArraySize isStarred) = isStarred
+    isVariableArraySize (ArraySize isStatic e) = isStatic || isConstantSize e
+
+    isConstantSize :: Expr -> Bool
+    isConstantSize (CConst (CIntConst {})) = True
+    isCosntantSize _ = False
+
+-- | Two types denote the same type if they are identical, ignoring type
+-- definitions, and neither is a variably modified type.
+sameType :: Type -> Type -> Bool
+sameType t1 t2 =
+  not (isVariablyModifiedType t1 || isVariablyModifiedType t2) && sameType' t1 t2
+  where
+    sameType' t1 t2 =
+      case (derefTypeDef t1, derefTypeDef t2) of
+        (TypeDefType {}, _) -> error "impossible: derefTypeDef t1 returned a TypeDefType"
+        (_, TypeDefType {}) -> error "impossible: derefTypeDef t2 returned a TypeDefType"
+        (DirectType tn1 q1 _a1, DirectType tn2 q2 _a2) ->
+          sameTypeName tn1 tn2 && sameQuals q1 q2 {- FIXME: same attributes? -}
+        (PtrType t1 q1 _a1, PtrType t2 q2 _a2) ->
+          sameType t1 t2 && sameQuals q1 q2
+        (ArrayType t1 sz1 q1 _a1, ArrayType t2 sz2 q2 _a2) ->
+          sameType t1 t2 && sameArraySize sz1 sz2 && sameQuals q1 q2
+        (FunctionType ft1 _a1, FunctionType ft2 _a2) ->
+          sameFunType ft1 ft2
+        _ -> False
+
+sameTypeName :: TypeName -> TypeName -> Bool
+sameTypeName t1 t2 =
+  case (t1, t2) of
+    (TyVoid, TyVoid) -> True
+    (TyIntegral i1, TyIntegral i2) -> i1 == i2
+    (TyFloating f1, TyFloating f2) -> f1 == f2
+    (TyComplex f1, TyComplex f2) -> f1 == f2
+    (TyComp ctr1, TyComp ctr2) -> sameCompTypeRef ctr1 ctr2
+    (TyEnum etr1, TyEnum etr2) -> sameEnumTypeRef etr1 etr2
+    (TyBuiltin b1, TyBuiltin b2) -> sameBuiltinType b1 b2
+    _ -> False
+
+sameBuiltinType :: BuiltinType -> BuiltinType -> Bool
+sameBuiltinType TyVaList TyVaList = True
+sameBuiltinType TyAny TyAny = False {- what does TyAny mean? -}
+sameBuiltinType _ _ = False
+
+sameCompTypeRef :: CompTypeRef -> CompTypeRef -> Bool
+sameCompTypeRef (CompTypeRef sue1 kind1 _) (CompTypeRef sue2 kind2 _) =
+  sue1 == sue2 && kind1 == kind2
+
+sameEnumTypeRef :: EnumTypeRef -> EnumTypeRef -> Bool
+sameEnumTypeRef (EnumTypeRef sue1 _) (EnumTypeRef sue2 _) = sue1 == sue2
+
+sameFunType :: FunType -> FunType -> Bool
+sameFunType (FunType rt1 params1 isVar1) (FunType rt2 params2 isVar2) =
+  sameType rt1 rt2 && sameParamDecls params1 params2 && isVar1 == isVar2
+  where
+    sameParamDecls :: [ParamDecl] -> [ParamDecl] -> Bool
+    sameParamDecls params1 params2 =
+      length params1 == length params2
+      && and (zipWith sameParamDecl params1 params2)
+    -- ignores param identifiers, just compares types
+    sameParamDecl :: ParamDecl -> ParamDecl -> Bool
+    sameParamDecl p1 p2 = sameType (declType p1) (declType p2)
+sameFunType (FunTypeIncomplete rt1) (FunTypeIncomplete rt2) =
+  sameType rt1 rt2
+
+-- | Returns 'True' iff both array sizes denote the same size.  Assumes that
+-- neither array type was a variably modified type.
+sameArraySize :: ArraySize -> ArraySize -> Bool
+sameArraySize (UnknownArraySize isStar1) (UnknownArraySize isStar2) = isStar1 == isStar2
+sameArraySize (ArraySize s1 e1) (ArraySize s2 e2) = s1 == s2 && sizeEqual e1 e2
+  where
+    -- FIXME: Do something better, and combine with sizeEqual in Language.C.Analysis.TypeCheck
+    sizeEqual :: Expr -> Expr -> Bool
+    sizeEqual (CConst (CIntConst i1 _)) (CConst (CIntConst i2 _)) = i1 == i2
+    sizeEqual e1 e2 = nodeInfo e1 == nodeInfo e2
+
+sameQuals :: TypeQuals -> TypeQuals -> Bool
+sameQuals (TypeQuals {constant = c1, volatile = v1, restrict = r1})
+          (TypeQuals {constant = c2, volatile = v2, restrict = r2}) =
+  c1 == c2 && v1 == v2 && r1 == r2
 
 canonicalType :: Type -> Type
 canonicalType t =


### PR DESCRIPTION
Also:

* in error messages, pretty print incompatible arithmetic type in comparison
* **[VERSION BUMP]** change `TypeDefRef` to store a `Type` not a `Maybe Type` 

Closes #24 
Closes #14 