### PR TITLE
Travis CI configuration (testing ghc 7.8, 7.10 and 8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,100 @@
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+#    - env: CABALVER=1.18 GHCVER=7.8.1 ALEXVER=3.1.7 HAPPYVER=1.19.5
+#      compiler: ": #GHC 7.8.1"
+#      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.1,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+#    - env: CABALVER=1.18 GHCVER=7.8.2 ALEXVER=3.1.7 HAPPYVER=1.19.5
+#      compiler: ": #GHC 7.8.2"
+#      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.2,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+#    - env: CABALVER=1.18 GHCVER=7.8.3 ALEXVER=3.1.7 HAPPYVER=1.19.5
+#      compiler: ": #GHC 7.8.3"
+#      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.3,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 ALEXVER=3.1.7 HAPPYVER=1.19.5
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+#    - env: CABALVER=1.22 GHCVER=7.10.1 ALEXVER=3.1.7 HAPPYVER=1.19.5
+#      compiler: ": #GHC 7.10.1"
+#      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+#    - env: CABALVER=1.22 GHCVER=7.10.2 ALEXVER=3.1.7 HAPPYVER=1.19.5
+#      compiler: ": #GHC 7.10.2"
+#      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 ALEXVER=3.1.7 HAPPYVER=1.19.5
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+#    - env: CABALVER=1.24 GHCVER=8.0.1 ALEXVER=3.1.7 HAPPYVER=1.19.5
+#      compiler: ": #GHC 8.0.1"
+#      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2 ALEXVER=3.1.7 HAPPYVER=1.19.5
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+
+before_install:
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u $HOME/.cabsnap/installplan.txt installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -7,6 +7,7 @@ INPLACE_PACKAGE_CONF=$(PROJECT_DIR)/dist/package.conf.inplace
 
 all: build
 build: $(INPLACE_PACKAGE_CONF)
+	cabal install --package-db $(INPLACE_PACKAGE_CONF) --dependencies-only
 	cabal configure --package-db $(INPLACE_PACKAGE_CONF)
 	cabal build
 	for b in $(BINARIES) ; do cp dist/build/$$b/$$b $(BIN_DIR) ; done

--- a/language-c.cabal
+++ b/language-c.cabal
@@ -16,6 +16,7 @@ Description:    Language C is a haskell library for the analysis and generation 
                 It features a complete, well tested parser and pretty printer for all of C99 and a large
                 set of GNU extensions.
 Category:       Language
+Tested-With:    GHC == 7.8.*, GHC == 7.10.*, GHC == 8.0.*
 
 Extra-Source-Files: AUTHORS AUTHORS.c2hs ChangeLog README
                     src/Language/C/Parser/Lexer.x

--- a/language-c.cabal
+++ b/language-c.cabal
@@ -40,7 +40,10 @@ Library
     Extensions: CPP, DeriveDataTypeable, PatternGuards, BangPatterns, ExistentialQuantification, GeneralizedNewtypeDeriving, ScopedTypeVariables
     Build-Depends:  filepath
     if flag(allWarnings)
-        ghc-options:     -Wall -Wno-redundant-constraints
+        if impl(ghc >= 8.0)
+          ghc-options:     -Wall -Wno-redundant-constraints
+        else
+          ghc-options:     -Wall
     if flag(splitBase)
         Build-Depends: base >= 3 && < 5, process, directory, array, containers, pretty
 

--- a/src/Language/C/Analysis/AstAnalysis.hs
+++ b/src/Language/C/Analysis/AstAnalysis.hs
@@ -105,6 +105,9 @@ analyseFunDef (CFunDef declspecs declr oldstyle_decls stmt node_info) = do
       return $ FunctionType (FunType return_ty [] False) attrs
     improveFunDefType ty = return ty
 
+voidM :: Monad m => m a -> m ()
+voidM m = m >> return ()
+
 -- | Analyse a declaration other than a function definition
 --
 --   Note: static assertions are not analysed
@@ -113,7 +116,7 @@ analyseDecl _is_local (CStaticAssert _expr _strlit _annot) = return () -- TODO
 analyseDecl is_local decl@(CDecl declspecs declrs node)
     | null declrs =
         case typedef_spec of Just _  -> astError node "bad typedef declaration: missing declarator"
-                             Nothing -> void$ analyseTypeDecl decl
+                             Nothing -> voidM$ analyseTypeDecl decl
     | (Just declspecs') <- typedef_spec = mapM_ (uncurry (analyseTyDef declspecs')) declr_list
     | otherwise   = do let (storage_specs, attrs, typequals, typespecs, funspecs, _alignspecs) =
                              partitionDeclSpecs declspecs
@@ -340,7 +343,7 @@ tStmt c (CCompound ls body _)    =
      return t
 tStmt c (CIf e sthen selse _)    =
   checkGuard c e >> tStmt c sthen
-                 >> maybe (return ()) (void . tStmt c) selse
+                 >> maybe (return ()) (voidM . tStmt c) selse
                  >> return voidType
 tStmt c (CSwitch e s ni)         =
   tExpr c RValue e >>= checkIntegral' ni >>
@@ -397,7 +400,7 @@ tStmt c (CFor i g inc s _)       =
      _ <- tStmt (LoopCtx : c) s
      leaveBlockScope
      return voidType
-  where checkExpr e = void$ tExpr c RValue e
+  where checkExpr e = voidM$ tExpr c RValue e
 tStmt c (CGotoPtr e ni)          =
   do t <- tExpr c RValue e
      case t of
@@ -695,7 +698,7 @@ tInitList ni t@(DirectType (TyComp ctr) _ _) initList =
      checkInits t default_ds initList
 tInitList _ (PtrType (DirectType TyVoid _ _) _ _ ) _ =
           return () -- XXX: more checking
-tInitList _ t [([], i)] = void$ tInit t i
+tInitList _ t [([], i)] = voidM$ tInit t i
 tInitList ni t _ = typeError ni $ "initializer list for type: " ++ pType t
 
 checkInits :: MonadTrav m => Type -> [CDesignator] -> CInitList -> m ()

--- a/src/Language/C/Analysis/AstAnalysis.hs
+++ b/src/Language/C/Analysis/AstAnalysis.hs
@@ -45,10 +45,12 @@ import Language.C.Syntax.Utils
 import Text.PrettyPrint.HughesPJ
 
 
-import Control.Monad
-import Prelude hiding (reverse)
+import Prelude hiding (mapM, mapM_, reverse)
+import Control.Monad hiding (mapM, mapM_)
 import qualified Data.Map as Map
 import Data.Maybe
+import Data.Traversable (mapM)
+import Data.Foldable (mapM_)
 
 -- * analysis
 

--- a/src/Language/C/Analysis/TravMonad.hs
+++ b/src/Language/C/Analysis/TravMonad.hs
@@ -64,6 +64,7 @@ import qualified Language.C.Analysis.DefTable as ST
 
 import Data.IntMap (insert)
 import Data.Maybe
+import Control.Applicative (Applicative(..))
 import Control.Monad (liftM, ap)
 import Prelude hiding (lookup)
 

--- a/src/Language/C/Parser/ParserMonad.hs
+++ b/src/Language/C/Parser/ParserMonad.hs
@@ -46,6 +46,7 @@ import Language.C.Data.Name    (Name)
 import Language.C.Data.Ident    (Ident)
 import Language.C.Parser.Tokens (CToken(CTokEof))
 
+import Control.Applicative (Applicative(..))
 import Control.Monad (liftM, ap)
 import Data.Set  (Set)
 import qualified Data.Set as Set (fromList, insert, member, delete)

--- a/test/language-c-test.cabal
+++ b/test/language-c-test.cabal
@@ -18,43 +18,67 @@ Category:       Language
 Executable CEquiv
    main-is: src/CEquiv.hs
    build-depends: base, filepath, mtl, pretty, language-c, language-c-test
-   ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   if impl(ghc >= 8.0)
+     ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   else
+     ghc-options:    -rtsopts -Wall
 
 Executable CParse
    main-is: src/CParse.hs
    build-depends: base, filepath, mtl, pretty, language-c, language-c-test
-   ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   if impl(ghc >= 8.0)
+     ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   else
+     ghc-options:    -rtsopts -Wall
 
 Executable CTest
    main-is: src/CTest.hs
    build-depends: base, filepath, mtl, pretty, syb, language-c, language-c-test
-   ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   if impl(ghc >= 8.0)
+     ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   else
+     ghc-options:    -rtsopts -Wall
 
 Executable CRoundTrip
    main-is: src/CRoundTrip.hs
    build-depends: base, filepath, mtl, pretty, language-c, language-c-test
-   ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   if impl(ghc >= 8.0)
+     ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   else
+     ghc-options:    -rtsopts -Wall
 
 Executable CheckGccArgs
    main-is: src/CheckGccArgs.hs
    build-depends: base, filepath, mtl, pretty, language-c, language-c-test
-   ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   if impl(ghc >= 8.0)
+     ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   else
+     ghc-options:    -rtsopts -Wall
 
 Executable RenderTests
    main-is: src/RenderTests.hs
    build-depends: base, filepath, mtl, pretty, containers, directory, xhtml, language-c, language-c-test
-   ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   if impl(ghc >= 8.0)
+     ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   else
+     ghc-options:    -rtsopts -Wall
 
 Executable ReportFatal
    main-is: src/ReportFatal.hs
    build-depends: base, filepath, mtl, pretty, language-c, language-c-test
-   ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   if impl(ghc >= 8.0)
+     ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+   else
+     ghc-options:    -rtsopts -Wall
 
 Library
     Extensions: CPP, DeriveDataTypeable, PatternGuards, BangPatterns, ExistentialQuantification, GeneralizedNewtypeDeriving, ScopedTypeVariables
     Build-Depends: base >= 3 && < 5, process, directory, array, containers, pretty, filepath, bytestring >= 0.9.0, syb, mtl, language-c >= 0.5.1
     Hs-Source-Dirs: src
-    ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+    if impl(ghc >= 8.0)
+      ghc-options:    -rtsopts -Wall -Wno-redundant-constraints
+    else
+      ghc-options:    -rtsopts -Wall
     Exposed-Modules:
                     Language.C.Test.Environment
                     Language.C.Test.Framework

--- a/test/src/Language/C/Test/TestMonad.hs
+++ b/test/src/Language/C/Test/TestMonad.hs
@@ -22,6 +22,7 @@ dbgMsg,addTestM,liftIOCatched,exitTest,errorOnInit,time,withTempFile_,withTempFi
 defaultMain,
 )
 where
+import Control.Applicative (Applicative (..))
 import Control.Exception (catch)
 import Control.Monad.Cont
 import Control.Monad.Reader


### PR DESCRIPTION
Like #27 but using a newer `multi-ghc-travis` to generate `.travis.yml`

Also assorted changes to build with older GHC versions:
1. AMP and FTP related changes
2. `-Wno-redundant-constraints` is only in ghc 8.0