### PR TITLE
Add `__float128`

### DIFF
--- a/README
+++ b/README
@@ -33,7 +33,6 @@ Currently unsupported C11 constructs:
 
 Currently unsupported GNU C extensions:
  - __auto_type
- - __float128
  - __builtin_offsetof
    char a[__builtin_offsetof (struct S, sa->f)
  - _Decimal32

--- a/src/Language/C/Parser/Lexer.x
+++ b/src/Language/C/Parser/Lexer.x
@@ -119,7 +119,8 @@ $infname  = . # [ \\ \" ]             -- valid character in a filename
 @hexmant   = @hexdigits?\.@hexdigits|@hexdigits\.
 @binexp    = [pP][\+\-]?@digits
 
-@floatsuffix    = [fFlL]
+-- Suffixes `qQwW` are GNU floating type extensions: <https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html>
+@floatsuffix    = [fFlLqQwW]
 @floatgnusuffix = @floatsuffix@gnusuffix?|@gnusuffix@floatsuffix?
 
 -- clang version literals with a major.minor.rev
@@ -297,7 +298,7 @@ label __label__
 (CTokGnuC GnuCOffsetof) __builtin_offsetof
 (CTokGnuC GnuCTyCompat) __builtin_types_compatible_p
 -}
--- Tokens: _Alignas _Alignof __alignof alignof __alignof__ __asm asm __asm__ _Atomic auto break _Bool case char __const const __const__ continue _Complex __complex__ default do double else enum extern float for _Generic goto if __inline inline __inline__ int __int128 long _Noreturn  _Nullable __nullable _Nonnull __nonnull register __restrict restrict __restrict__ return short __signed signed __signed__ sizeof static _Static_assert struct switch typedef __typeof typeof __typeof__ __thread _Thread_local union unsigned void __volatile volatile __volatile__ while __label__ __attribute __attribute__ __extension__ __real __real__ __imag __imag__ __builtin_va_arg __builtin_offsetof __builtin_types_compatible_p
+-- Tokens: _Alignas _Alignof __alignof alignof __alignof__ __asm asm __asm__ _Atomic auto break _Bool case char __const const __const__ continue _Complex __complex__ default do double else enum extern float __float128 for _Generic goto if __inline inline __inline__ int __int128 long _Noreturn  _Nullable __nullable _Nonnull __nonnull register __restrict restrict __restrict__ return short __signed signed __signed__ sizeof static _Static_assert struct switch typedef __typeof typeof __typeof__ __thread _Thread_local union unsigned void __volatile volatile __volatile__ while __label__ __attribute __attribute__ __extension__ __real __real__ __imag __imag__ __builtin_va_arg __builtin_offsetof __builtin_types_compatible_p
 idkwtok ('_' : 'A' : 'l' : 'i' : 'g' : 'n' : 'a' : 's' : []) = tok 8 CTokAlignas
 idkwtok ('_' : 'A' : 'l' : 'i' : 'g' : 'n' : 'o' : 'f' : []) = tok 8 CTokAlignof
 idkwtok ('_' : 'A' : 't' : 'o' : 'm' : 'i' : 'c' : []) = tok 7 CTokAtomic
@@ -337,6 +338,7 @@ idkwtok ('e' : 'n' : 'u' : 'm' : []) = tok 4 CTokEnum
 idkwtok ('_' : '_' : 'e' : 'x' : 't' : 'e' : 'n' : 's' : 'i' : 'o' : 'n' : '_' : '_' : []) = tok 13 (CTokGnuC GnuCExtTok)
 idkwtok ('e' : 'x' : 't' : 'e' : 'r' : 'n' : []) = tok 6 CTokExtern
 idkwtok ('f' : 'l' : 'o' : 'a' : 't' : []) = tok 5 CTokFloat
+idkwtok ('_' : '_' : 'f' : 'l' : 'o' : 'a' : 't' : '1' : '2' : '8' : []) = tok 10 CTokFloat128
 idkwtok ('f' : 'o' : 'r' : []) = tok 3 CTokFor
 idkwtok ('g' : 'o' : 't' : 'o' : []) = tok 4 CTokGoto
 idkwtok ('i' : 'f' : []) = tok 2 CTokIf

--- a/src/Language/C/Parser/Parser.y
+++ b/src/Language/C/Parser/Parser.y
@@ -201,6 +201,7 @@ else		{ CTokElse	_ }
 enum		{ CTokEnum	_ }
 extern		{ CTokExtern	_ }
 float		{ CTokFloat	_ }
+"__float128"	{ CTokFloat128	_ }
 for		{ CTokFor	_ }
 "_Generic"      { CTokGeneric   _ }
 goto		{ CTokGoto	_ }
@@ -872,6 +873,7 @@ basic_type_name
   | "_Bool"			{% withNodeInfo $1 $ CBoolType }
   | "_Complex"			{% withNodeInfo $1 $ CComplexType }
   | "__int128"      {% withNodeInfo $1 $ CInt128Type }
+  | "__float128"      {% withNodeInfo $1 $ CFloat128Type }
 
 
 -- A mixture of type qualifiers, storage class and basic type names in any

--- a/src/Language/C/Parser/Tokens.hs
+++ b/src/Language/C/Parser/Tokens.hs
@@ -92,6 +92,7 @@ data CToken = CTokLParen   !PosLength            -- `('
             | CTokEnum     !PosLength            -- `enum'
             | CTokExtern   !PosLength            -- `extern'
             | CTokFloat    !PosLength            -- `float'
+            | CTokFloat128 !PosLength            -- `__float128'
             | CTokFor      !PosLength            -- `for'
             | CTokGeneric  !PosLength            -- `_Generic'
             | CTokGoto     !PosLength            -- `goto'
@@ -224,6 +225,7 @@ posLenOfTok (CTokElse     pos  ) = pos
 posLenOfTok (CTokEnum     pos  ) = pos
 posLenOfTok (CTokExtern   pos  ) = pos
 posLenOfTok (CTokFloat    pos  ) = pos
+posLenOfTok (CTokFloat128 pos  ) = pos
 posLenOfTok (CTokFor      pos  ) = pos
 posLenOfTok (CTokGeneric  pos  ) = pos
 posLenOfTok (CTokGoto     pos  ) = pos
@@ -330,6 +332,7 @@ instance Show CToken where
   showsPrec _ (CTokEnum     _  ) = showString "enum"
   showsPrec _ (CTokExtern   _  ) = showString "extern"
   showsPrec _ (CTokFloat    _  ) = showString "float"
+  showsPrec _ (CTokFloat128 _  ) = showString "__float128"
   showsPrec _ (CTokFor      _  ) = showString "for"
   showsPrec _ (CTokGeneric  _  ) = showString "_Generic"
   showsPrec _ (CTokGoto     _  ) = showString "goto"

--- a/src/Language/C/Pretty.hs
+++ b/src/Language/C/Pretty.hs
@@ -244,6 +244,7 @@ instance Pretty CTypeSpec where
     pretty (CIntType _)         = text "int"
     pretty (CLongType _)        = text "long"
     pretty (CFloatType _)       = text "float"
+    pretty (CFloat128Type _)    = text "__float128"
     pretty (CDoubleType _)      = text "double"
     pretty (CSignedType _)      = text "signed"
     pretty (CUnsigType _)       = text "unsigned"

--- a/src/Language/C/Syntax/AST.hs
+++ b/src/Language/C/Syntax/AST.hs
@@ -434,6 +434,7 @@ data CTypeSpecifier a
   | CIntType     a
   | CLongType    a
   | CFloatType   a
+  | CFloat128Type a
   | CDoubleType  a
   | CSignedType  a
   | CUnsigType   a
@@ -1028,6 +1029,7 @@ instance CNode t1 => CNode (CTypeSpecifier t1) where
         nodeInfo (CIntType d) = nodeInfo d
         nodeInfo (CLongType d) = nodeInfo d
         nodeInfo (CFloatType d) = nodeInfo d
+        nodeInfo (CFloat128Type d) = nodeInfo d
         nodeInfo (CDoubleType d) = nodeInfo d
         nodeInfo (CSignedType d) = nodeInfo d
         nodeInfo (CUnsigType d) = nodeInfo d
@@ -1050,6 +1052,7 @@ instance Functor CTypeSpecifier where
         fmap _f (CIntType a1) = CIntType (_f a1)
         fmap _f (CLongType a1) = CLongType (_f a1)
         fmap _f (CFloatType a1) = CFloatType (_f a1)
+        fmap _f (CFloat128Type a1) = CFloat128Type (_f a1)
         fmap _f (CDoubleType a1) = CDoubleType (_f a1)
         fmap _f (CSignedType a1) = CSignedType (_f a1)
         fmap _f (CUnsigType a1) = CUnsigType (_f a1)
@@ -1070,6 +1073,7 @@ instance Annotated CTypeSpecifier where
         annotation (CIntType n) = n
         annotation (CLongType n) = n
         annotation (CFloatType n) = n
+        annotation (CFloat128Type n) = n
         annotation (CDoubleType n) = n
         annotation (CSignedType n) = n
         annotation (CUnsigType n) = n
@@ -1088,6 +1092,7 @@ instance Annotated CTypeSpecifier where
         amap f (CIntType a_1) = CIntType (f a_1)
         amap f (CLongType a_1) = CLongType (f a_1)
         amap f (CFloatType a_1) = CFloatType (f a_1)
+        amap f (CFloat128Type a_1) = CFloat128Type (f a_1)
         amap f (CDoubleType a_1) = CDoubleType (f a_1)
         amap f (CSignedType a_1) = CSignedType (f a_1)
         amap f (CUnsigType a_1) = CUnsigType (f a_1)

--- a/test/harness/parse_dg/expect_fail.txt
+++ b/test/harness/parse_dg/expect_fail.txt
@@ -31,8 +31,6 @@ a.20.1.i
 addsub.i
 alias-17.i
 allconv.i
-alloca-5.i
-alloca-6.i
 allop-const.i
 allop.i
 altivec-types.i
@@ -118,8 +116,6 @@ constants-c99.i
 constants-hex.i
 constants.i
 constants-pedantic.i
-const-float128.i
-const-float128-ped.i
 const-float80.i
 const-float80-ped.i
 const-ll-1.i
@@ -193,14 +189,6 @@ fe-binop.i
 fe-convert-1.i
 fe-convert-2.i
 fe-convert-3.i
-float128-cmp-invalid.i
-float128-div-underflow.i
-float128-exact-underflow.i
-float128-extend-nan.i
-float128-extendxf-underflow.i
-float128-mul-underflow.i
-float128-truncdf-underflow.i
-float128-truncsf-underflow.i
 float-cast-overflow-atomic.i
 float-constant-double.i
 fltconst-1.i
@@ -211,10 +199,6 @@ fltconst-pedantic-dfp.i
 fold-nonneg-1.i
 for-1.i
 fp-int-convert-2.i
-fp-int-convert-float128.i
-fp-int-convert-float128-timode-2.i
-fp-int-convert-float128-timode-3.i
-fp-int-convert-float128-timode.i
 fp-int-convert-float80.i
 fp-int-convert-float80-timode.i
 fpreprocessed.i
@@ -355,7 +339,6 @@ pr47690.i
 pr47744-2.i
 pr47905.i
 pr48204.i
-pr48591.i
 pr48928.i
 pr51106-1.i
 pr51106-2.i

--- a/test/harness/parse_dg/expect_parse.txt
+++ b/test/harness/parse_dg/expect_parse.txt
@@ -593,6 +593,8 @@ alloca-1.i
 alloca-2.i
 alloca-3.i
 alloca-4.i
+alloca-5.i
+alloca-6.i
 alpha-1.i
 always_inline2.i
 always_inline3.i
@@ -1462,6 +1464,8 @@ const-2.i
 const-3.i
 const-elim-1.i
 const-elim-2.i
+const-float128.i
+const-float128-ped.i
 constructor-1.i
 const-uniq_0.i
 const-uniq_1.i
@@ -1749,6 +1753,14 @@ float-range-2.i
 float-range-3.i
 float-range-4.i
 float-range-5.i
+float128-cmp-invalid.i
+float128-div-underflow.i
+float128-exact-underflow.i
+float128-extend-nan.i
+float128-extendxf-underflow.i
+float128-mul-underflow.i
+float128-truncdf-underflow.i
+float128-truncsf-underflow.i
 flush-1.i
 flush-2.i
 fnegate-1.i
@@ -1902,6 +1914,10 @@ forwprop-9.i
 fp-compare.i
 fp-int-convert-double.i
 fp-int-convert-float.i
+fp-int-convert-float128-timode-2.i
+fp-int-convert-float128-timode-3.i
+fp-int-convert-float128-timode.i
+fp-int-convert-float128.i
 fp-int-convert-long-double.i
 fp-int-convert-timode.i
 free-1.i
@@ -4360,6 +4376,7 @@ pr48524.i
 pr48542.i
 pr48552-1.i
 pr48552-2.i
+pr48591.i
 pr48616.i
 pr48622_0.i
 pr48685.i


### PR DESCRIPTION
https://github.com/gcc-mirror/gcc/commit/9b5c49ef97e63cc63f1ffa13baf771368105ebe2 (circa gcc 7.1) references `__float128` in `stddef.h` when `__i386__` is defined. This breaks a lot packages (e.g. https://github.com/haskell/c2hs/issues/191　https://github.com/gtk2hs/gtk2hs/issues/200) depending on c2hs (which in turn depends on language-c).

```
  Syntax error !
  The symbol `__float128' does not fit here.
```

This pull request adds support for `__float128` and corresponding `qQwW` floating point literal suffixes (https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html) to address the issue.

`parse_dg` regression tests are also updated.
