### PR TITLE
Support clang’s __builtin_convertvector

### DIFF
--- a/language-c.cabal
+++ b/language-c.cabal
@@ -1,5 +1,5 @@
 Name:           language-c
-Version:        0.6.1
+Version:        0.6.2
 Cabal-Version:  >= 1.8
 Build-Type:     Simple
 License:        BSD3

--- a/src/Language/C/Parser/Lexer.x
+++ b/src/Language/C/Parser/Lexer.x
@@ -296,8 +296,9 @@ label __label__
 (CTokGnuC GnuCVaArg) __builtin_va_arg
 (CTokGnuC GnuCOffsetof) __builtin_offsetof
 (CTokGnuC GnuCTyCompat) __builtin_types_compatible_p
+(CTokClangC ClangBuiltinConvertVector) __builtin_convertvector
 -}
--- Tokens: _Alignas _Alignof __alignof alignof __alignof__ __asm asm __asm__ _Atomic auto break _Bool case char __const const __const__ continue _Complex __complex__ default do double else enum extern float for _Generic goto if __inline inline __inline__ int __int128 long _Noreturn  _Nullable __nullable _Nonnull __nonnull register __restrict restrict __restrict__ return short __signed signed __signed__ sizeof static _Static_assert struct switch typedef __typeof typeof __typeof__ __thread _Thread_local union unsigned void __volatile volatile __volatile__ while __label__ __attribute __attribute__ __extension__ __real __real__ __imag __imag__ __builtin_va_arg __builtin_offsetof __builtin_types_compatible_p
+-- Tokens: _Alignas _Alignof __alignof alignof __alignof__ __asm asm __asm__ _Atomic auto break _Bool case char __const const __const__ continue _Complex __complex__ default do double else enum extern float for _Generic goto if __inline inline __inline__ int __int128 long _Noreturn  _Nullable __nullable _Nonnull __nonnull register __restrict restrict __restrict__ return short __signed signed __signed__ sizeof static _Static_assert struct switch typedef __typeof typeof __typeof__ __thread _Thread_local union unsigned void __volatile volatile __volatile__ while __label__ __attribute __attribute__ __extension__ __real __real__ __imag __imag__ __builtin_va_arg __builtin_offsetof __builtin_types_compatible_p __builtin_convertvector
 idkwtok ('_' : 'A' : 'l' : 'i' : 'g' : 'n' : 'a' : 's' : []) = tok 8 CTokAlignas
 idkwtok ('_' : 'A' : 'l' : 'i' : 'g' : 'n' : 'o' : 'f' : []) = tok 8 CTokAlignof
 idkwtok ('_' : 'A' : 't' : 'o' : 'm' : 'i' : 'c' : []) = tok 7 CTokAtomic
@@ -322,6 +323,7 @@ idkwtok ('b' : 'r' : 'e' : 'a' : 'k' : []) = tok 5 CTokBreak
 idkwtok ('_' : '_' : 'b' : 'u' : 'i' : 'l' : 't' : 'i' : 'n' : '_' : 'o' : 'f' : 'f' : 's' : 'e' : 't' : 'o' : 'f' : []) = tok 18 (CTokGnuC GnuCOffsetof)
 idkwtok ('_' : '_' : 'b' : 'u' : 'i' : 'l' : 't' : 'i' : 'n' : '_' : 't' : 'y' : 'p' : 'e' : 's' : '_' : 'c' : 'o' : 'm' : 'p' : 'a' : 't' : 'i' : 'b' : 'l' : 'e' : '_' : 'p' : []) = tok 28 (CTokGnuC GnuCTyCompat)
 idkwtok ('_' : '_' : 'b' : 'u' : 'i' : 'l' : 't' : 'i' : 'n' : '_' : 'v' : 'a' : '_' : 'a' : 'r' : 'g' : []) = tok 16 (CTokGnuC GnuCVaArg)
+idkwtok ('_' : '_' : 'b' : 'u' : 'i' : 'l' : 't' : 'i' : 'n' : '_' : 'c' : 'o' : 'n' : 'v' : 'e' : 'r' : 't' : 'v' : 'e' : 'c' : 't' : 'o' : 'r' : []) = tok 23 (flip CTokClangC ClangBuiltinConvertVector)
 idkwtok ('c' : 'a' : 's' : 'e' : []) = tok 4 CTokCase
 idkwtok ('c' : 'h' : 'a' : 'r' : []) = tok 4 CTokChar
 idkwtok ('_' : '_' : 'c' : 'o' : 'm' : 'p' : 'l' : 'e' : 'x' : '_' : '_' : []) = tok 11 CTokComplex

--- a/src/Language/C/Parser/Parser.y
+++ b/src/Language/C/Parser/Parser.y
@@ -245,6 +245,7 @@ tyident		{ CTokTyIdent _ $$ }		-- `typedef-name' identifier
 "__builtin_va_arg"		{ CTokGnuC GnuCVaArg    _ }
 "__builtin_offsetof"		{ CTokGnuC GnuCOffsetof _ }
 "__builtin_types_compatible_p"	{ CTokGnuC GnuCTyCompat _ }
+"__builtin_convertvector"	{ CTokClangC _ ClangBuiltinConvertVector }
 clangcversion   { CTokClangC _ (ClangCVersionTok $$) } -- Clang version literal
 
 %%
@@ -1734,6 +1735,9 @@ primary_expression
 
   | "__builtin_types_compatible_p" '(' type_name ',' type_name ')'
   	{% withNodeInfo $1 $ CBuiltinExpr . CBuiltinTypesCompatible $3 $5 }
+
+  | "__builtin_convertvector" '(' assignment_expression ',' type_name ')'
+        {% withNodeInfo $1 $ CBuiltinExpr . CBuiltinConvertVector $3 $5 }
 
 -- Generic Selection association list (C11 6.5.1.1)
 --

--- a/src/Language/C/Parser/Tokens.hs
+++ b/src/Language/C/Parser/Tokens.hs
@@ -153,6 +153,7 @@ data GnuCTok = GnuCAttrTok              -- `__attribute__'
              | GnuCComplexImag          -- `__imag__'
 
 data ClangCTok = ClangCVersionTok !ClangCVersion -- version constant from 'availability' attribute
+               | ClangBuiltinConvertVector
 
 instance Pos CToken where
   posOf = fst . posLenOfTok

--- a/src/Language/C/Syntax/AST.hs
+++ b/src/Language/C/Syntax/AST.hs
@@ -716,6 +716,7 @@ data CBuiltinThing a
   = CBuiltinVaArg (CExpression a) (CDeclaration a) a            -- ^ @(expr, type)@
   | CBuiltinOffsetOf (CDeclaration a) [CPartDesignator a] a -- ^ @(type, designator-list)@
   | CBuiltinTypesCompatible (CDeclaration a) (CDeclaration a) a  -- ^ @(type,type)@
+  | CBuiltinConvertVector (CExpression a) (CDeclaration a) a -- ^ @(expr, type)@
     deriving (Show, Data,Typeable {-! ,CNode ,Functor ,Annotated !-})
 
 
@@ -1322,6 +1323,7 @@ instance CNode t1 => CNode (CBuiltinThing t1) where
         nodeInfo (CBuiltinVaArg _ _ n) = nodeInfo n
         nodeInfo (CBuiltinOffsetOf _ _ n) = nodeInfo n
         nodeInfo (CBuiltinTypesCompatible _ _ n) = nodeInfo n
+        nodeInfo (CBuiltinConvertVector _ _ n) = nodeInfo n
 instance CNode t1 => Pos (CBuiltinThing t1) where
         posOf x = posOf (nodeInfo x)
 
@@ -1332,16 +1334,21 @@ instance Functor CBuiltinThing where
           = CBuiltinOffsetOf (fmap _f a1) (fmap (fmap _f) a2) (_f a3)
         fmap _f (CBuiltinTypesCompatible a1 a2 a3)
           = CBuiltinTypesCompatible (fmap _f a1) (fmap _f a2) (_f a3)
+        fmap _f (CBuiltinConvertVector a1 a2 a3)
+          = CBuiltinConvertVector (fmap _f a1) (fmap _f a2) (_f a3)
 
 instance Annotated CBuiltinThing where
         annotation (CBuiltinVaArg _ _ n) = n
         annotation (CBuiltinOffsetOf _ _ n) = n
         annotation (CBuiltinTypesCompatible _ _ n) = n
+        annotation (CBuiltinConvertVector _ _ n) = n
         amap f (CBuiltinVaArg a_1 a_2 a_3) = CBuiltinVaArg a_1 a_2 (f a_3)
         amap f (CBuiltinOffsetOf a_1 a_2 a_3)
           = CBuiltinOffsetOf a_1 a_2 (f a_3)
         amap f (CBuiltinTypesCompatible a_1 a_2 a_3)
           = CBuiltinTypesCompatible a_1 a_2 (f a_3)
+        amap f (CBuiltinConvertVector a_1 a_2 a_3) =
+          CBuiltinConvertVector a_1 a_2 (f a_3)
 
 instance CNode t1 => CNode (CConstant t1) where
         nodeInfo (CIntConst _ n) = nodeInfo n


### PR DESCRIPTION
<https://clang.llvm.org/docs/LanguageExtensions.html#langext-builtin-convertvector>

This function requires special lexing and parsing support since it
takes a type as an argument.

Fixes #34