### PR TITLE
(.travis.yml) Add GHC 8.2.1 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ matrix:
     - env: CABALVER=1.24 GHCVER=8.0.2 ALEXVER=3.1.7 HAPPYVER=1.19.5
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.2.1 ALEXVER=3.1.7 HAPPYVER=1.19.5
+      compiler: ": #GHC 8.2.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.2.1,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+
 
 before_install:
  - unset CC

--- a/language-c.cabal
+++ b/language-c.cabal
@@ -16,7 +16,7 @@ Description:    Language C is a haskell library for the analysis and generation 
                 It features a complete, well tested parser and pretty printer for all of C99 and a large
                 set of C11 and clang/GNU extensions.
 Category:       Language
-Tested-With:    GHC == 7.8.*, GHC == 7.10.*, GHC == 8.0.*
+Tested-With:    GHC == 7.8.*, GHC == 7.10.*, GHC == 8.0.*, GHC == 8.2.1
 
 Extra-Source-Files: AUTHORS AUTHORS.c2hs ChangeLog README
                     src/Language/C/Parser/Lexer.x


### PR DESCRIPTION
`language-c` seems to build fine with the newly-released GHC 8.2.1, for what it's worth.