### PR TITLE
Remove non-standard \e escape

### DIFF
--- a/src/Language/C/Syntax/Constants.hs
+++ b/src/Language/C/Syntax/Constants.hs
@@ -246,7 +246,6 @@ escapeChar :: Char -> String
 escapeChar '\\' = "\\\\"
 escapeChar '\a' = "\\a"
 escapeChar '\b' = "\\b"
-escapeChar '\ESC' = "\\e";
 escapeChar '\f' = "\\f"
 escapeChar '\n' = "\\n"
 escapeChar '\r' = "\\r"


### PR DESCRIPTION
`\e` is commonly supported but nonstandard; compiling with `-Wpedantic` results a warning: `use of non-standard escape character '\e' [-Wpedantic]`. The hex/octal versions would be better since they're part of the standard.