### PR TITLE
Add support parse OpenCL kernel function declaration

### DIFF
--- a/src/Language/C/Analysis/AstAnalysis.hs
+++ b/src/Language/C/Analysis/AstAnalysis.hs
@@ -183,6 +183,7 @@ computeFunDefStorage ident other_spec  = do
   let defaultSpec = FunLinkage ExternalLinkage
   case other_spec of
     NoStorageSpec  -> return$ maybe defaultSpec declStorage obj_opt
+    ClKernelSpec  -> return$ maybe defaultSpec declStorage obj_opt
     (ExternSpec False) -> return$ maybe defaultSpec declStorage obj_opt
     bad_spec -> throwTravError $ badSpecifierError (nodeInfo ident)
                   $ "unexpected function storage specifier (only static or extern is allowed)" ++ show bad_spec

--- a/src/Language/C/Analysis/SemRep.hs
+++ b/src/Language/C/Analysis/SemRep.hs
@@ -493,26 +493,30 @@ instance Declaration Enumerator where
 -- | Type qualifiers: constant, volatile and restrict
 data TypeQuals = TypeQuals { constant :: Bool, volatile :: Bool,
                              restrict :: Bool, atomic :: Bool,
-                             nullable :: Bool, nonnull  :: Bool }
+                             nullable :: Bool, nonnull  :: Bool,
+                             clrdonly :: Bool, clwronly :: Bool }
     deriving (Typeable, Data)
 
 instance Eq TypeQuals where
- (==) (TypeQuals c1 v1 r1 a1 n1 nn1) (TypeQuals c2 v2 r2 a2 n2 nn2) =
+ (==) (TypeQuals c1 v1 r1 a1 n1 nn1 rd1 wr1) (TypeQuals c2 v2 r2 a2 n2 nn2 rd2 wr2) =
     c1 == c2 && v1 == v2 && r1 == r2 && a1 == a2 && n1 == n2 && nn1 == nn2
+    && rd1 == rd2 && wr1 == wr2
 
 instance Ord TypeQuals where
-  (<=) (TypeQuals c1 v1 r1 a1 n1 nn1) (TypeQuals c2 v2 r2 a2 n2 nn2) =
+  (<=) (TypeQuals c1 v1 r1 a1 n1 nn1 rd1 wr1) (TypeQuals c2 v2 r2 a2 n2 nn2 rd2 wr2) =
     c1 <= c2 && v1 <= v2 && r1 <= r2 && a1 <= a2 && n1 <= n2 && nn1 <= nn2
+    && rd1 <= rd2 && wr1 <= wr2
 
 
 -- | no type qualifiers
 noTypeQuals :: TypeQuals
-noTypeQuals = TypeQuals False False False False False False
+noTypeQuals = TypeQuals False False False False False False False False
 
 -- | merge (/&&/) two type qualifier sets
 mergeTypeQuals :: TypeQuals -> TypeQuals -> TypeQuals
-mergeTypeQuals (TypeQuals c1 v1 r1 a1 n1 nn1) (TypeQuals c2 v2 r2 a2 n2 nn2) =
+mergeTypeQuals (TypeQuals c1 v1 r1 a1 n1 nn1 rd1 wr1) (TypeQuals c2 v2 r2 a2 n2 nn2 rd2 wr2) =
   TypeQuals (c1 && c2) (v1 && v2) (r1 && r2) (a1 && a2) (n1 && n2) (nn1 && nn2)
+            (rd1 && rd2) (wr1 && wr2)
 
 -- * initializers
 

--- a/src/Language/C/Parser/Lexer.x
+++ b/src/Language/C/Parser/Lexer.x
@@ -356,6 +356,7 @@ idkwtok ('_' : '_' : 'c' : 'o' : 'm' : 'p' : 'l' : 'e' : 'x' : '_' : '_' : []) =
 idkwtok ('_' : '_' : 'c' : 'o' : 'n' : 's' : 't' : []) = tok 7 CTokConst
 idkwtok ('c' : 'o' : 'n' : 's' : 't' : []) = tok 5 CTokConst
 idkwtok ('_' : '_' : 'c' : 'o' : 'n' : 's' : 't' : '_' : '_' : []) = tok 9 CTokConst
+idkwtok ('_' : '_' : 'c' : 'o' : 'n' : 's' : 't' : 'a' : 'n' : 't' : []) = tok 10 CTokConst
 idkwtok ('c' : 'o' : 'n' : 't' : 'i' : 'n' : 'u' : 'e' : []) = tok 8 CTokContinue
 idkwtok ('d' : 'e' : 'f' : 'a' : 'u' : 'l' : 't' : []) = tok 7 CTokDefault
 idkwtok ('d' : 'o' : []) = tok 2 CTokDo
@@ -415,6 +416,12 @@ idkwtok ('_' : 'F' : 'l' : 'o' : 'a' : 't' : '6' : '4' : 'x' : []) = tok 9 (CTok
 idkwtok ('_' : 'F' : 'l' : 'o' : 'a' : 't' : '1' : '2' : '8' : []) = tok 9 (CTokFloatN 128 False)
 idkwtok ('_' : 'F' : 'l' : 'o' : 'a' : 't' : '1' : '2' : '8' : 'x' : []) = tok 10 (CTokFloatN 128 True)
 #endif
+-- For OpenCL tokens
+idkwtok ('_' : '_' : 'k' : 'e' : 'r' : 'n' : 'e' : 'l' : []) = tok 8 CTokClKernel
+idkwtok ('_' : '_' : 'r' : 'e' : 'a' : 'd' : '_' : 'o' : 'n' : 'l' : 'y' : []) = tok 11 CTokClRdOnly
+idkwtok ('_' : '_' : 'w' : 'r' : 'i' : 't' : 'e' : '_' : 'o' : 'n' : 'l' : 'y' : []) = tok 12 CTokClWrOnly
+idkwtok ('_' : '_' : 'g' : 'l' : 'o' : 'b' : 'a' : 'l' : []) = tok 8 CTokClGlobal
+idkwtok ('_' : '_' : 'l' : 'o' : 'c' : 'a' : 'l' : []) = tok 7 CTokClLocal
 
 idkwtok cs = \pos -> do
   name <- getNewName

--- a/src/Language/C/Parser/Tokens.hs
+++ b/src/Language/C/Parser/Tokens.hs
@@ -141,6 +141,11 @@ data CToken = CTokLParen   !PosLength            -- `('
             | CTokTyIdent  !PosLength !Ident     -- `typedef-name' identifier
             | CTokGnuC !GnuCTok !PosLength       -- special GNU C tokens
             | CTokClangC !PosLength !ClangCTok   -- special Clang C tokens
+            | CTokClKernel !PosLength            -- OpenCL `__kernel'
+            | CTokClRdOnly !PosLength            -- OpenCL `__read_only'
+            | CTokClWrOnly !PosLength            -- OpenCL `__write_only'
+            | CTokClGlobal !PosLength            -- OpenCL `__Global'
+            | CTokClLocal  !PosLength            -- OpenCL `__Local'
             | CTokEof                           -- end of file
 
 -- special tokens used in GNU C extensions to ANSI C
@@ -265,6 +270,11 @@ posLenOfTok (CTokIdent    pos _) = pos
 posLenOfTok (CTokTyIdent  pos _) = pos
 posLenOfTok (CTokGnuC   _ pos  ) = pos
 posLenOfTok (CTokClangC   pos _) = pos
+posLenOfTok (CTokClKernel pos  ) = pos
+posLenOfTok (CTokClRdOnly pos  ) = pos
+posLenOfTok (CTokClWrOnly pos  ) = pos
+posLenOfTok (CTokClGlobal pos  ) = pos
+posLenOfTok (CTokClLocal  pos  ) = pos
 posLenOfTok CTokEof = error "tokenPos: Eof"
 
 instance Show CToken where
@@ -380,4 +390,9 @@ instance Show CToken where
   showsPrec _ (CTokGnuC GnuCTyCompat _) = showString "__builtin_types_compatible_p"
   showsPrec _ (CTokClangC _ (ClangCVersionTok v)) = shows v
   showsPrec _ (CTokClangC _ ClangBuiltinConvertVector) = showString "__builtin_convertvector"
+  showsPrec _ (CTokClKernel _  ) = showString "__kernel"
+  showsPrec _ (CTokClRdOnly _  ) = showString "__read_only"
+  showsPrec _ (CTokClWrOnly _  ) = showString "__write_only"
+  showsPrec _ (CTokClGlobal _  ) = showString "__global"
+  showsPrec _ (CTokClLocal  _  ) = showString "__Local"
   showsPrec _ CTokEof = error "show CToken : CTokEof"

--- a/src/Language/C/Pretty.hs
+++ b/src/Language/C/Pretty.hs
@@ -237,6 +237,9 @@ instance Pretty CStorageSpec where
     pretty (CExtern _) = text "extern"
     pretty (CTypedef _) = text "typedef"
     pretty (CThread _) = text "_Thread_local"
+    pretty (CClKernel _) = text "__kernel"
+    pretty (CClGlobal _) = text "__global"
+    pretty (CClLocal _)  = text "__local"
 
 instance Pretty CTypeSpec where
     pretty (CVoidType _)        = text "void"
@@ -271,6 +274,8 @@ instance Pretty CTypeQual where
     pretty (CAttrQual a)  = attrlistP [a]
     pretty (CNullableQual _) = text "_Nullable"
     pretty (CNonnullQual _) = text "_Nonnull"
+    pretty (CClRdOnlyQual _) = text "__read_only"
+    pretty (CClWrOnlyQual _) = text "__write_only"
 
 instance Pretty CFunSpec where
     pretty (CInlineQual _) = text "inline"

--- a/src/Language/C/Syntax/AST.hs
+++ b/src/Language/C/Syntax/AST.hs
@@ -440,6 +440,9 @@ data CStorageSpecifier a
   | CExtern   a     -- ^ extern
   | CTypedef  a     -- ^ typedef
   | CThread   a     -- ^ C11/GNUC thread local storage
+  | CClKernel a     -- ^ OpenCL kernel function
+  | CClGlobal a     -- ^ OpenCL __global variable
+  | CClLocal  a     -- ^ OpenCL __local variable
     deriving (Show, Eq,Ord,Data,Typeable, Generic, Generic1 {-! ,CNode ,Functor ,Annotated !-})
 
 instance NFData a => NFData (CStorageSpecifier a)
@@ -495,6 +498,8 @@ data CTypeQualifier a
   | CAttrQual  (CAttribute a)
   | CNullableQual a
   | CNonnullQual a
+  | CClRdOnlyQual a
+  | CClWrOnlyQual a
     deriving (Show, Data,Typeable, Generic, Generic1 {-! ,CNode ,Functor ,Annotated !-})
 
 instance NFData a => NFData (CTypeQualifier a)
@@ -1039,6 +1044,9 @@ instance CNode t1 => CNode (CStorageSpecifier t1) where
         nodeInfo (CExtern d) = nodeInfo d
         nodeInfo (CTypedef d) = nodeInfo d
         nodeInfo (CThread d) = nodeInfo d
+        nodeInfo (CClKernel d) = nodeInfo d
+        nodeInfo (CClGlobal d) = nodeInfo d
+        nodeInfo (CClLocal d) = nodeInfo d
 instance CNode t1 => Pos (CStorageSpecifier t1) where
         posOf x = posOf (nodeInfo x)
 
@@ -1049,6 +1057,9 @@ instance Functor CStorageSpecifier where
         fmap _f (CExtern a1) = CExtern (_f a1)
         fmap _f (CTypedef a1) = CTypedef (_f a1)
         fmap _f (CThread a1) = CThread (_f a1)
+        fmap _f (CClKernel a1) = CClKernel (_f a1)
+        fmap _f (CClGlobal a1) = CClGlobal (_f a1)
+        fmap _f (CClLocal a1) = CClLocal (_f a1)
 
 instance Annotated CStorageSpecifier where
         annotation (CAuto n) = n
@@ -1057,12 +1068,18 @@ instance Annotated CStorageSpecifier where
         annotation (CExtern n) = n
         annotation (CTypedef n) = n
         annotation (CThread n) = n
+        annotation (CClKernel n) = n
+        annotation (CClGlobal n) = n
+        annotation (CClLocal n) = n
         amap f (CAuto a_1) = CAuto (f a_1)
         amap f (CRegister a_1) = CRegister (f a_1)
         amap f (CStatic a_1) = CStatic (f a_1)
         amap f (CExtern a_1) = CExtern (f a_1)
         amap f (CTypedef a_1) = CTypedef (f a_1)
         amap f (CThread a_1) = CThread (f a_1)
+        amap f (CClKernel a_1) = CClKernel (f a_1)
+        amap f (CClGlobal a_1) = CClGlobal (f a_1)
+        amap f (CClLocal a_1) = CClLocal (f a_1)
 
 instance CNode t1 => CNode (CTypeSpecifier t1) where
         nodeInfo (CVoidType d) = nodeInfo d
@@ -1156,6 +1173,8 @@ instance CNode t1 => CNode (CTypeQualifier t1) where
         nodeInfo (CAttrQual d) = nodeInfo d
         nodeInfo (CNullableQual d) = nodeInfo d
         nodeInfo (CNonnullQual d) = nodeInfo d
+        nodeInfo (CClRdOnlyQual d) = nodeInfo d
+        nodeInfo (CClWrOnlyQual d) = nodeInfo d
 
 instance CNode t1 => Pos (CTypeQualifier t1) where
         posOf x = posOf (nodeInfo x)
@@ -1168,6 +1187,8 @@ instance Functor CTypeQualifier where
         fmap _f (CAttrQual a1) = CAttrQual (fmap _f a1)
         fmap _f (CNullableQual a1) = CNullableQual (_f a1)
         fmap _f (CNonnullQual a1) = CNonnullQual (_f a1)
+        fmap _f (CClRdOnlyQual a1) = CClRdOnlyQual (_f a1)
+        fmap _f (CClWrOnlyQual a1) = CClWrOnlyQual (_f a1)
 
 instance Annotated CTypeQualifier where
         annotation (CConstQual n) = n
@@ -1177,6 +1198,8 @@ instance Annotated CTypeQualifier where
         annotation (CAttrQual n) = annotation n
         annotation (CNullableQual n) = n
         annotation (CNonnullQual n) = n
+        annotation (CClRdOnlyQual n) = n
+        annotation (CClWrOnlyQual n) = n
         amap f (CConstQual a_1) = CConstQual (f a_1)
         amap f (CVolatQual a_1) = CVolatQual (f a_1)
         amap f (CRestrQual a_1) = CRestrQual (f a_1)
@@ -1184,6 +1207,8 @@ instance Annotated CTypeQualifier where
         amap f (CAttrQual n) = CAttrQual (amap f n)
         amap f (CNullableQual a_1) = CNullableQual (f a_1)
         amap f (CNonnullQual a_1) = CNonnullQual (f a_1)
+        amap f (CClRdOnlyQual a_1) = CClRdOnlyQual (f a_1)
+        amap f (CClWrOnlyQual a_1) = CClWrOnlyQual (f a_1)
 
 instance CNode t1 => CNode (CFunctionSpecifier t1) where
         nodeInfo (CInlineQual d) = nodeInfo d


### PR DESCRIPTION
In this patch, I add some tokens for parse OpenCL's kernel function declaration. It can used for parse kernel function declaration and generate wrapper function for call OpenCL kernel by function clEnqueueNDRangeKernel.
My project clkernel-parser is now use this patch to generate wrapper functions from source code file *.cl.