### PR TITLE
Remove dependency on syb

### DIFF
--- a/language-c.cabal
+++ b/language-c.cabal
@@ -29,8 +29,6 @@ Source-Repository head
 Flag useByteStrings
     Description: Use ByteString as InputStream datatype
     Default: True
-Flag separateSYB
-  description: Data.Generics available in separate package.
 Flag allWarnings
     Description: Turn on all warnings for building (development)
     Default: False
@@ -54,13 +52,8 @@ Library
         else
           ghc-options:     -Wall
 
-    If flag(separateSYB)
-        Build-Depends:
-          base >=4 && <5,
-          syb
-    Else
-        Build-Depends:
-          base <4
+    Build-Depends:
+      base >=4 && <5
 
     if flag(useByteStrings)
         Build-Depends: bytestring >= 0.9.0

--- a/src/Language/C/Analysis/DefTable.hs
+++ b/src/Language/C/Analysis/DefTable.hs
@@ -40,7 +40,8 @@ import Language.C.Analysis.SemRep
 import qualified Data.Map as Map
 import Data.IntMap (IntMap, union)
 import qualified Data.IntMap as IntMap
-import Data.Generics
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 
 {- Name spaces, scopes and contexts [Scopes]
 

--- a/src/Language/C/Analysis/SemRep.hs
+++ b/src/Language/C/Analysis/SemRep.hs
@@ -58,7 +58,8 @@ import Language.C.Syntax
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
-import Data.Generics
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 
 -- | accessor class : struct\/union\/enum names
 class HasSUERef a where

--- a/src/Language/C/Data/Ident.hs
+++ b/src/Language/C/Data/Ident.hs
@@ -28,7 +28,8 @@ import Data.Char
 import Language.C.Data.Position
 import Language.C.Data.Node
 import Language.C.Data.Name (Name)
-import Data.Generics hiding (Generic)
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 

--- a/src/Language/C/Data/Name.hs
+++ b/src/Language/C/Data/Name.hs
@@ -12,8 +12,9 @@
 module Language.C.Data.Name (
 Name(..),newNameSupply, namesStartingFrom
 ) where
+import Data.Data (Data)
 import Data.Ix
-import Data.Generics hiding (Generic)
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 

--- a/src/Language/C/Data/Node.hs
+++ b/src/Language/C/Data/Node.hs
@@ -21,7 +21,8 @@ module Language.C.Data.Node (
 ) where
 import Language.C.Data.Position
 import Language.C.Data.Name     (Name)
-import Data.Generics hiding (Generic)
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 

--- a/src/Language/C/Data/Position.hs
+++ b/src/Language/C/Data/Position.hs
@@ -27,7 +27,8 @@ module Language.C.Data.Position (
   incOffset,
   Pos(..),
 ) where
-import Data.Generics hiding (Generic)
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 

--- a/src/Language/C/Syntax/AST.hs
+++ b/src/Language/C/Syntax/AST.hs
@@ -62,7 +62,8 @@ import Language.C.Syntax.Ops
 import Language.C.Data.Ident
 import Language.C.Data.Node
 import Language.C.Data.Position
-import Data.Generics hiding (Generic)
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic, Generic1)
 import Control.DeepSeq (NFData)
 

--- a/src/Language/C/Syntax/Constants.hs
+++ b/src/Language/C/Syntax/Constants.hs
@@ -30,7 +30,8 @@ where
 import Data.Bits
 import Data.Char
 import Numeric (showOct, showHex, readHex, readOct, readDec)
-import Data.Generics hiding (Generic)
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic, Generic1)
 import Control.DeepSeq (NFData)
 

--- a/src/Language/C/Syntax/Ops.hs
+++ b/src/Language/C/Syntax/Ops.hs
@@ -25,7 +25,8 @@ CUnaryOp(..),
 isEffectfulOp
 )
 where
-import Data.Generics hiding (Generic)
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 -- | C assignment operators (K&R A7.17)


### PR DESCRIPTION
As far as I can tell, `language-c` used `syb` to import `Data` and `Typeable`. For all recent GHCs, one can do this directly.

(This allows `language-c` to build with GHC 9.0 as syb currently is not up-to-date https://github.com/dreixel/syb/issues/27)