### PR TITLE
Support empty asm clobbers list after colon

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@
 
 ## WIP
 
+## 0.9.1
+
+  - Support parsing an empty list of clobbers after a colon in `asm` statements
+
 ## 0.9.0.2
 
 	- Correct lower bound on GHC

--- a/language-c.cabal
+++ b/language-c.cabal
@@ -1,5 +1,5 @@
 Name:           language-c
-Version:        0.9.0.2
+Version:        0.9.1
 Cabal-Version:  >= 1.10
 Build-Type:     Simple
 License:        BSD3

--- a/src/Language/C/Parser/Parser.y
+++ b/src/Language/C/Parser/Parser.y
@@ -527,7 +527,7 @@ asm_statement
   	{% withNodeInfo $1 $ CAsmStmt $2 $4 $6 $8 [] }
 
   | asm maybe_type_qualifier '(' string_literal ':' asm_operands ':' asm_operands ':' asm_clobbers ')' ';'
-  	{% withNodeInfo $1 $ CAsmStmt $2 $4 $6 $8 (reverse $10) }
+  	{% withNodeInfo $1 $ CAsmStmt $2 $4 $6 $8 $10 }
 
 
 maybe_type_qualifier :: { Maybe CTypeQual }
@@ -551,11 +551,15 @@ asm_operand
   | '[' ident ']' string_literal '(' expression ')'   {% withNodeInfo $1 $ CAsmOperand (Just $2) $4 $6 }
   | '[' tyident ']' string_literal '(' expression ')' {% withNodeInfo $1 $ CAsmOperand (Just $2) $4 $6 }
 
-
-asm_clobbers :: { Reversed [CStrLit] }
+asm_clobbers :: { [CStrLit] }
 asm_clobbers
-  : string_literal			        { singleton $1 }
-  | asm_clobbers ',' string_literal	{ $1 `snoc` $3 }
+  : {- empty -}             { [] }
+  | nonnull_asm_clobbers    { reverse $1 }
+
+nonnull_asm_clobbers :: { Reversed [CStrLit] }
+nonnull_asm_clobbers
+  : string_literal                          { singleton $1 }
+  | nonnull_asm_clobbers ',' string_literal { $1 `snoc` $3 }
 
 {-
 ---------------------------------------------------------------------------------------------------------------

--- a/test/harness/parse_dg/expect_fail.txt
+++ b/test/harness/parse_dg/expect_fail.txt
@@ -219,7 +219,6 @@ instrumented-mask.i
 int-warning.i
 ipa-1.i
 ipa-2.i
-ipa-icf-27.i
 irrevocable-1.i
 irrevocable-2.i
 irrevocable-3.i

--- a/test/harness/parse_dg/expect_parse.txt
+++ b/test/harness/parse_dg/expect_parse.txt
@@ -2250,6 +2250,7 @@ ipa-icf-23.i
 ipa-icf-24.i
 ipa-icf-25.i
 ipa-icf-26.i
+ipa-icf-27.i
 ipa-icf-28.i
 ipa-icf-29.i
 ipa-icf-2.i


### PR DESCRIPTION
Parses code such as the following which compiles in both GCC and Clang:

```c
int main(int argc, char const *argv[])
{
  __asm__ ("mov %%eax, %%eax"
    :
    :
    : );
  return 0;
}
```

In the parser I simply modified `asm_clobbers` to look just like `asm_operands` which also supports being empty after a colon.

I was going to add a test case, and upon running the harness found there was already one at `test/harness/parse_dg/gcc_pre/ipa-icf-27.i` marked as "should fail to parse", with the contents:

```c
# 1 "ipa-icf-27.c"
# 1 "<built-in>"
# 1 "<command-line>"
# 31 "<command-line>"
# 1 "/usr/include/stdc-predef.h" 1 3 4
# 32 "<command-line>" 2
# 1 "ipa-icf-27.c"



void destroy (void)
{
  __asm__ __volatile__ ("" : : : "memory");
}

void remove (void)
{
  __asm__ __volatile__ ("" : : : "memory");
}

void remove2 (void)
{
  __asm__ __volatile__ ("" : : : );
}

int main()
{
  destroy ();
  remove ();
  remove2 ();

  return 0;
}
```

This also compiles fine, so I just moved it to be marked as "should parse".