### PR TITLE
Fix #86: correct base to >= 4.8 (GHC 7.10)

### DIFF
--- a/language-c.cabal
+++ b/language-c.cabal
@@ -37,7 +37,7 @@ Flag iecFpExtension
     Default: True
 Library
     default-extensions: CPP, DeriveDataTypeable, DeriveGeneric, PatternGuards, BangPatterns, ExistentialQuantification, GeneralizedNewtypeDeriving, ScopedTypeVariables
-    Build-Depends: base >= 4.7 && < 5,
+    Build-Depends: base >= 4.8 && < 5,
                    array,
                    containers >= 0.3,
                    deepseq >= 1.4.0.0 && < 1.5,
@@ -52,9 +52,6 @@ Library
         else
           ghc-options:     -Wall
 
-    Build-Depends:
-      base >=4 && <5
-
     if flag(useByteStrings)
         Build-Depends: bytestring >= 0.9.0
     else
@@ -62,10 +59,6 @@ Library
 
     if flag(iecFpExtension)
         cpp-options: -DIEC_60559_TYPES_EXT
-
-     -- GHC.Generics lived in `ghc-prim` for GHC 7.2 & GHC 7.4
-    if impl(ghc == 7.4.*)
-        build-depends: ghc-prim == 0.2.*
 
     Build-Tools:    happy, alex
 


### PR DESCRIPTION
Fix #86: correct base to >= 4.8 (GHC 7.10)

7.10 is the least GHC `language-c` builds with.