### PR TITLE
Use `bool` as the pretty name for the type/token/etc.

### DIFF
--- a/src/Language/C/Analysis/SemRep.hs
+++ b/src/Language/C/Analysis/SemRep.hs
@@ -410,7 +410,7 @@ data IntType =
     deriving (Data, Eq, Ord)
 
 instance Show IntType where
-    show TyBool = "_Bool"
+    show TyBool = "bool"
     show TyChar = "char"
     show TySChar = "signed char"
     show TyUChar = "unsigned char"

--- a/src/Language/C/Parser/Parser.y
+++ b/src/Language/C/Parser/Parser.y
@@ -192,7 +192,7 @@ alignas         { CTokAlignas   _ }
 asm		{ CTokAsm	_ }
 auto		{ CTokAuto	_ }
 break		{ CTokBreak	_ }
-"_Bool"		{ CTokBool	_ }
+bool		{ CTokBool	_ }
 case		{ CTokCase	_ }
 char		{ CTokChar	_ }
 const		{ CTokConst	_ }
@@ -901,7 +901,7 @@ basic_type_name
   | double			{% withNodeInfo $1 $ CDoubleType }
   | signed			{% withNodeInfo $1 $ CSignedType }
   | unsigned			{% withNodeInfo $1 $ CUnsigType }
-  | "_Bool"			{% withNodeInfo $1 $ CBoolType }
+  | bool			{% withNodeInfo $1 $ CBoolType }
   | "_Complex"			{% withNodeInfo $1 $ CComplexType }
   | "__int128"                  {% withNodeInfo $1 $ CInt128Type }
   | "__int128_t"                {% withNodeInfo $1 $ CInt128Type }

--- a/src/Language/C/Parser/Tokens.hs
+++ b/src/Language/C/Parser/Tokens.hs
@@ -78,7 +78,7 @@ data CToken = CTokLParen   !PosLength            -- `('
             | CTokAtomic   !PosLength            -- `_Atomic'
             | CTokAuto     !PosLength            -- `auto'
             | CTokBreak    !PosLength            -- `break'
-            | CTokBool     !PosLength            -- `_Bool'
+            | CTokBool     !PosLength            -- `bool'
             | CTokCase     !PosLength            -- `case'
             | CTokChar     !PosLength            -- `char'
             | CTokConst    !PosLength            -- `const'
@@ -338,7 +338,7 @@ instance Show CToken where
   showsPrec _ (CTokAsm      _  ) = showString "asm"
   showsPrec _ (CTokAtomic      _  ) = showString "_Atomic"
   showsPrec _ (CTokAuto     _  ) = showString "auto"
-  showsPrec _ (CTokBool _)       = showString "_Bool"
+  showsPrec _ (CTokBool _)       = showString "bool"
   showsPrec _ (CTokBreak    _  ) = showString "break"
   showsPrec _ (CTokCase     _  ) = showString "case"
   showsPrec _ (CTokChar     _  ) = showString "char"

--- a/src/Language/C/Pretty.hs
+++ b/src/Language/C/Pretty.hs
@@ -254,7 +254,7 @@ instance Pretty CTypeSpec where
     pretty (CDoubleType _)      = text "double"
     pretty (CSignedType _)      = text "signed"
     pretty (CUnsigType _)       = text "unsigned"
-    pretty (CBoolType _)        = text "_Bool"
+    pretty (CBoolType _)        = text "bool"
     pretty (CComplexType _)     = text "_Complex"
     pretty (CInt128Type _)      = text "__int128"
     pretty (CUInt128Type _)     = text "__uint128"


### PR DESCRIPTION
Since all variants of the keyword share a name, we need to pick one (as the parser/lexer forget the original string). I feel like using bool is less confusing in common situations, but I may be wrong.